### PR TITLE
Remove forum sunrise

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ group :development, :test do
   gem 'capybara'
   gem 'factory_bot_rails'
   gem 'rspec-rails', '~> 5.0.0'
-  gem 'timecop'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,7 +229,6 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     thor (1.1.0)
-    timecop (0.9.4)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     warden (1.2.9)
@@ -271,7 +270,6 @@ DEPENDENCIES
   rspec-rails (~> 5.0.0)
   sentry-rails
   sentry-ruby
-  timecop
   tzinfo-data
   web-console (>= 4.1.0)
   webpacker (~> 5.4.0)

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,14 +1,8 @@
 class TopicsController < ApplicationController
     after_action :log_topic_view, only: %i[show create update]
 
-    def today
-        @topics = Topic.all.updated_today
-        @topic_views = TopicView.where(user: current_user).where(topic: @topics).order('created_at DESC').group_by{|tv| tv.topic_id }
-        @mentions = UserMention.where(user: current_user).includes(:post).where(post: { topic: @topics }).order('user_mentions.created_at DESC').group_by{|um| um.post.topic_id }
-    end
-
     def index
-        @topics = Topic.all.updated_before
+        @topics = Topic.all.by_most_recent_post
         @topic_views = TopicView.where(user: current_user).where(topic: @topics).order('created_at DESC').group_by{|tv| tv.topic_id }
         @mentions = UserMention.where(user: current_user).includes(:post).where(post: { topic: @topics }).order('user_mentions.created_at DESC').group_by{|um| um.post.topic_id }
     end

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -19,38 +19,4 @@ class Topic < ApplicationRecord
           AND posts.id = (#{subquery.to_sql})
       SQL
     }
-
-    scope :updated_today, -> {
-        subquery = Post.select(:id)
-                       .where("posts.topic_id = topics.id")
-                       .order(created_at: :desc).limit(1)
-      
-        joins(<<-SQL).where('posts.created_at >= ?', sunrise).order('posts.created_at DESC')
-          LEFT JOIN posts
-            ON posts.topic_id = topics.id
-            AND posts.id = (#{subquery.to_sql})
-        SQL
-      }
-
-    scope :updated_before, -> {
-        subquery = Post.select(:id)
-                       .where("posts.topic_id = topics.id")
-                       .order(created_at: :desc).limit(1)
-      
-        joins(<<-SQL).where('posts.created_at < ?', sunrise).order('posts.created_at DESC')
-          LEFT JOIN posts
-            ON posts.topic_id = topics.id
-            AND posts.id = (#{subquery.to_sql})
-        SQL
-      }
-
-    def self.sunrise
-        # ~midnight Pacific / 8am London
-        current_datetime = Time.now.utc.to_datetime
-        if current_datetime.hour >= 8
-          current_datetime.change(hour: 8, min: 0, sec: 0)
-        else
-          current_datetime.change(day: (current_datetime.day - 1), hour: 8, min: 0, sec: 0)
-        end
-    end
 end

--- a/app/views/topics/_table.html.erb
+++ b/app/views/topics/_table.html.erb
@@ -1,4 +1,4 @@
-<table class="w-full">
+<table class="w-full my-3">
 <thead>
     <tr class="py-1 bg-sky-400 border-b-2 border-yellow-100 text-left">
         <th class="pl-3 w-1">@<span class="sr-only">new mentions</span></th>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,6 +1,5 @@
-<h1 class="text-lg">past topics</h1>
+<h1 class="text-lg">topics</h1>
 
 <%= render 'table', topics: @topics, topic_views: @topic_views, mentions: @mentions %>
 
-<%= link_to "today's news", today_topics_path, class: "link block my-3" %>
-<%= link_to "new topic", new_topic_path, class: "btn inline-block mb-3" %>
+<%= link_to "new topic", new_topic_path, class: "btn inline-block" %>

--- a/app/views/topics/mentions.html.erb
+++ b/app/views/topics/mentions.html.erb
@@ -1,7 +1,6 @@
-<h1 class="text-lg">past topics you've been mentioned in</h1>
+<h1 class="text-lg">topics you've been mentioned in</h1>
 
 <%= render 'table', topics: @topics, topic_views: @topic_views, mentions: @mentions %>
 
-<%= link_to "today's news", today_topics_path, class: "link block mt-3" %>
-<%= link_to "yesterday's news", topics_path, class: "link block mb-3" %>
+<%= link_to "back to topics", topics_path, class: "link block mb-3" %>
 <%= link_to "new topic", new_topic_path, class: "btn inline-block mb-3" %>

--- a/app/views/topics/today.html.erb
+++ b/app/views/topics/today.html.erb
@@ -1,6 +1,0 @@
-<h1 class="text-lg">today's topics</h1>
-
-<%= render 'table', topics: @topics, topic_views: @topic_views, mentions: @mentions %>
-
-<%= link_to "yesterday's news", topics_path, class: "link block my-3" %>
-<%= link_to "new topic", new_topic_path, class: "btn inline-block mb-3" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,11 +2,10 @@ Rails.application.routes.draw do
   devise_for :users
   
   resources :topics, except: %i[edit delete], constraints: { id: /\d+/ }
-  get 'topics/today', to: 'topics#today', as: :today_topics
   get 'topics/mentions', to: 'topics#mentions', as: :my_mentions
 
   resources :profile, only: %i[show edit update], param: :username
   get 'profile', to: 'profile#mine', as: :my_profile
 
-  root 'topics#today'
+  root 'topics#index'
 end

--- a/spec/system/account_management_spec.rb
+++ b/spec/system/account_management_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Account management", type: :system do
     fill_in 'password', with: 'password1234'
     click_on 'log in'
 
-    expect(page).to have_content("today's topics")
+    expect(page).to have_content("topics")
 
     click_on 'my profile'
 

--- a/spec/system/user_views_threads_spec.rb
+++ b/spec/system/user_views_threads_spec.rb
@@ -10,74 +10,6 @@ RSpec.describe "Creating and viewing topics", type: :system do
     sign_in poster
   end
 
-  it 'observes forum sunrise' do
-    Timecop.travel(DateTime.new(2021, 01, 02, 12, 0, 0, 0)) do # 12pm UTC
-      create(:topic, title: 'this will be an old topic', author: poster)
-      
-      visit '/'
-      
-      topics = page.all(:xpath, "//table/tbody/tr")
-      expect(topics.length).to eq(1)
-      expect(topics.first).to have_content 'this will be an old topic'
-    end
-    
-    Timecop.travel(DateTime.new(2021, 01, 03, 0, 0, 0, 0)) do # 12:00 am next day, UTC
-      visit '/'
-      
-      expect(page.all(:xpath, "//table/tbody/tr").length).to eq(1)
-      
-      click_on 'new topic'
-      
-      fill_in 'title', with: 'this will also be an old topic'
-      fill_in 'body', with: "asdf"
-      click_on 'post'
-      
-      click_on 'back to topics'
-      
-      expect(page.all(:xpath, "//table/tbody/tr").length).to eq(2)
-      expect(page).to have_content "today's topics"
-      expect(page).to have_content 'this will be an old topic'
-      expect(page).to have_content 'this will also be an old topic'
-    end
-    
-    Timecop.travel(DateTime.new(2021, 01, 03, 8, 0, 0, 0)) do # 8:00 am next day, UTC
-      visit '/'
-
-      expect(page.all(:xpath, "//table/tbody/tr").length).to eq(0)
-
-      click_on 'new topic'
-
-      fill_in 'title', with: 'this is a new topic'
-      fill_in 'body', with: "asdf"
-      click_on 'post'
-  
-      click_on 'back to topics'
-  
-      expect(page.all(:xpath, "//table/tbody/tr").length).to eq(1)
-      expect(page).to have_content "today's topics"
-      expect(page).to have_content 'this is a new topic'
-
-      click_on "yesterday's news"
-  
-      expect(page.all(:xpath, "//table/tbody/tr").length).to eq(2)
-      expect(page).to have_content "past topics"
-      expect(page).to have_content 'this will be an old topic'
-      expect(page).to have_content 'this will also be an old topic'
-
-      click_on 'this will be an old topic'
-  
-      fill_in 'reply', with: 'bring it to the front'
-      click_on 'post'
-  
-      click_on 'back to topics'
-  
-      expect(page).to have_content "today's topics"
-      expect(page.all(:xpath, "//table/tbody/tr").length).to eq(2)
-      expect(page).to have_content 'this is a new topic'
-      expect(page).to have_content 'this will be an old topic'
-    end
-  end
-
   it "should allow logged in user to create a new topic and view it" do
     visit '/'
 
@@ -90,7 +22,7 @@ RSpec.describe "Creating and viewing topics", type: :system do
     expect(page).to have_content 'post your dogs'
     click_on 'back to topics'
 
-    expect(page).to have_content "today's topics"
+    expect(page).to have_content 'topics'
     expect(page).to have_content 'post your dogs'
 
     logout
@@ -110,8 +42,8 @@ RSpec.describe "Creating and viewing topics", type: :system do
   end
 
   it 'shows notifications for unread posts' do
-    create(:topic, title: 'this is a topic', author: poster)
-    create(:topic, title: 'but this is the one I made', author: viewer)
+    create(:topic, title: 'this is a topic', author: poster, created_at: 1.day.ago)
+    create(:topic, title: 'but this is the one I made', author: viewer, created_at: Time.now)
 
     visit '/'
 


### PR DESCRIPTION
Think this doesn't make sense for low-volume forums, and I want to
explore better ways of organizing threads. Also it made user
interactions needlessly complicated.

Related to #30